### PR TITLE
[codex] Add civitai.red and civitai.green support for Chrome

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Stability Matrix CivitAI Integration",
   "description": "This extension adds a button to the CivitAI interface that allows you download a given model with Stability Matrix.",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "action": {
     "default_icon": "icon.png"
   },
@@ -13,7 +13,11 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://civitai.com/*"],
+      "matches": [
+        "https://civitai.com/*",
+        "https://civitai.red/*",
+        "https://civitai.green/*"
+      ],
       "js": ["script.js"],
       "run_at": "document_end"
     }


### PR DESCRIPTION
## Summary
- extend the extension manifest host matches to include `https://civitai.red/*` and `https://civitai.green/*`
- keep the existing `https://civitai.com/*` match intact
- bump the Chrome extension version to `1.0.7`

## Why
The extension only matched `civitai.com`, so the content script never ran on the new `civitai.red` and `civitai.green` domains.

## Impact
Chrome users get the Stability Matrix download integration on all three supported Civitai domains.

## Validation
- parsed `manifest.json` successfully after the change
- verified the content script match list now includes all three domains
- exported a fresh `1.0.7` package from the committed tree
